### PR TITLE
Do not automatically require sinatra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - ruby-head
-  - rbx-19mode
-  - jruby-19mode
   - jruby-head
 
 matrix:

--- a/lib/redis-sinatra.rb
+++ b/lib/redis-sinatra.rb
@@ -1,4 +1,3 @@
-require 'sinatra'
 require 'redis-store'
 require 'redis-sinatra/version'
 require 'sinatra/cache/redis_store'

--- a/redis-sinatra.gemspec
+++ b/redis-sinatra.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'redis-store', '>= 1.1', '< 2'
-  s.add_dependency 'sinatra',     '~> 1.4.0'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.3'


### PR DESCRIPTION
hello everybody,

I've started using Redis for cache and I am very happy to have found these `redis-store` gems, thank you so much. It is working very well on Rails.

However, `redis-sinatra` doesn't work in my case because the gem automatically require full Sinatra adding its DSL to the global namespace, which breaks all my rake tasks.

This issue is quite frequent and is documented [here](http://aaronlerch.github.io/blog/sinatra-bundler-and-the-global-namespace/).

Don't you think is it better to not force requiring full Sinatra, letting people free to load it the way it fits to their project?

 Let me know if my explanation is not clear enough and/or if you have any questions